### PR TITLE
fix: Update rootProject name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "kmp-template"
+rootProject.name = "KMP-Template"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {


### PR DESCRIPTION
There was a mismatch between the project name specified in your settings.gradle file and the actual name of your project directory.